### PR TITLE
Context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ yarn-error.log*
 !.vscode/launch.json
 !.vscode/extensions.json
 .history/*
+/.vscode

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import './App.css';
 import DevtoolsPane from './devtoolsPane';
+import { ObservableProvider } from './contexts/observableContext';
 
 
-function App() {
+export default function App() {
+
   return (
-    <div className='App'>
-      <DevtoolsPane />
-    </div>
+    <ObservableProvider>
+      <div className='App'>
+        <DevtoolsPane />
+      </div>
+    </ObservableProvider>
   );
 }
-
-export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,19 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import './App.css';
 import DevtoolsPane from './devtoolsPane';
 import { ObservableProvider } from './contexts/observableContext';
+import { EventProvider } from './contexts/eventContext';
 
 
 export default function App() {
 
   return (
     <ObservableProvider>
-      <div className='App'>
-        <DevtoolsPane />
-      </div>
+      <EventProvider>
+        <div className='App'>
+          <DevtoolsPane />
+        </div>
+      </EventProvider>
     </ObservableProvider>
   );
 }

--- a/src/content.js
+++ b/src/content.js
@@ -1,22 +1,38 @@
-import { Observable } from 'rxjs';
+//@ts-check
+import { Observable, Subject } from 'rxjs';
+import { getObservableMock } from './mockMessages';
 
 export const observable$ = new Observable();
 export const event$ = new Observable();
 export const operator$ = new Observable();
 export let print = console.log; // For development purpose.
 
+// Mock some messages for development.
 const mockMessages = () => {
     return new Observable(subscriber => {
-        subscriber.next('Hello World.');
+        // subscriber.next('Hello World.');
+        dispatchMessage(subscriber, getObservableMock())
     });
 };
 
-let test = function() {
+const childs$ = new Map();
 
+// Dispatch given message over given subscriber.
+const dispatchMessage = (subscriber, message) => {
+    switch (message.type) {
+        case 'observable':
+            const { message: observable } = message;
+            observable.child$ = new Subject();
+            childs$.set(observable.uuid, observable.child$);
+            subscriber.next({ type: 'observable', message: observable }); break;
+    }
 }
+
 const development = true;
+
+// Get message source$.
 export const getMessage$ = () => {
-    if (development)    // Outside extension there is no chrome object.
+    if (development)   // Outside extension there is no chrome object.
         return new Promise(resolve => resolve(mockMessages()));
 
     declare var chrome; // Declaration required to satisfy compiler, filled by chrome.
@@ -29,7 +45,8 @@ export const getMessage$ = () => {
         resolve(
             new Observable(subscriber => {
                 backgroundPageConnection.addListener(msg => {
-                    subscriber.next(msg);
+                    // subscriber.next(msg);
+                    dispatchMessage(subscriber, msg);
                 });
             })
         );

--- a/src/content.js
+++ b/src/content.js
@@ -64,7 +64,7 @@ const dispatchMessage = (subscriber, message) => {
 }
 
 // Development flag.
-const development = true;
+const development = false;
 
 // Get promise of message source$.
 export const getMessage$ = () => {

--- a/src/content.js
+++ b/src/content.js
@@ -12,11 +12,18 @@ const mockMessages = () => {
     return new Observable(subscriber => {
         const observable = getObservableMock();
         const pipe = getPipeMock(observable.message.uuid);
+        const pipe2 = getPipeMock(observable.message.uuid);
         dispatchMessage(subscriber, observable);
         dispatchMessage(subscriber, getObservableMock());
         dispatchMessage(subscriber, pipe);
+        dispatchMessage(subscriber, pipe2);
         dispatchMessage(subscriber, getOperatorMock(observable.message.uuid, pipe.message.uuid));
-        dispatchMessage(subscriber, getSubscriptionMock(observable, [pipe]));
+        dispatchMessage(subscriber, getOperatorMock(observable.message.uuid, pipe.message.uuid));
+        dispatchMessage(subscriber, getOperatorMock(observable.message.uuid, pipe.message.uuid));
+        dispatchMessage(subscriber, getOperatorMock(observable.message.uuid, pipe2.message.uuid));
+        dispatchMessage(subscriber, getSubscriptionMock(observable.message.uuid, [pipe.message.uuid]));
+        dispatchMessage(subscriber, getSubscriptionMock(observable.message.uuid, []));
+        dispatchMessage(subscriber, getSubscriptionMock(observable.message.uuid, [pipe2.message.uuid]));
     });
 };
 
@@ -57,7 +64,7 @@ export const getMessage$ = () => {
     return new Promise(resolve => {
         resolve(
             new Observable(subscriber => {
-                backgroundPageConnection.addListener(msg => {
+                backgroundPageConnection.onMessage.addListener(msg => {
                     // subscriber.next(msg);
                     dispatchMessage(subscriber, msg);
                 });

--- a/src/content.js
+++ b/src/content.js
@@ -14,6 +14,7 @@ const mockMessages = () => {
         const pipe = getPipeMock(observable.message.uuid);
         const pipe2 = getPipeMock(observable.message.uuid);
         const operator1  = getOperatorMock(observable.message.uuid, pipe.message.uuid);
+        const subscription1 = getSubscriptionMock(observable.message.uuid, [pipe.message.uuid]);
         dispatchMessage(subscriber, observable);
         dispatchMessage(subscriber, getObservableMock());
         dispatchMessage(subscriber, pipe);
@@ -22,7 +23,7 @@ const mockMessages = () => {
         dispatchMessage(subscriber, getOperatorMock(observable.message.uuid, pipe.message.uuid));
         dispatchMessage(subscriber, getOperatorMock(observable.message.uuid, pipe.message.uuid));
         dispatchMessage(subscriber, getOperatorMock(observable.message.uuid, pipe2.message.uuid));
-        dispatchMessage(subscriber, getSubscriptionMock(observable.message.uuid, [pipe.message.uuid]));
+        dispatchMessage(subscriber, subscription1);
         dispatchMessage(subscriber, getSubscriptionMock(observable.message.uuid, []));
         dispatchMessage(subscriber, getSubscriptionMock(observable.message.uuid, [pipe2.message.uuid]));
         dispatchMessage(subscriber, getEventMock('1', pipe, 'initial'));
@@ -31,6 +32,9 @@ const mockMessages = () => {
         dispatchMessage(subscriber, getEventMock('1', operator1.message.uuid, 'operator'));
         dispatchMessage(subscriber, getEventMock('2', operator1.message.uuid, 'operator'));
         dispatchMessage(subscriber, getEventMock('3', operator1.message.uuid, 'operator'));
+        dispatchMessage(subscriber, getEventMock('1', subscription1.message.uuid, 'subscribe'));
+        dispatchMessage(subscriber, getEventMock('2', subscription1.message.uuid, 'subscribe'));
+        dispatchMessage(subscriber, getEventMock('3', subscription1.message.uuid, 'subscribe'));
     });
 };
 

--- a/src/content.js
+++ b/src/content.js
@@ -1,63 +1,94 @@
-import { Subject, interval, zip } from 'rxjs';
-import { filter, pluck, map } from 'rxjs/operators';
-import { getObservableMock, getOperatorMock, getEventMock } from './mockMessages';
+import { Observable } from 'rxjs';
 
-const timer$ = interval(10);
-const backpageMessageSubject$ = new Subject();
-const backpageMessageSubjectEmiter$ = zip(backpageMessageSubject$, timer$).pipe(
-    map(([value, _]) => value)
-);
+export const observable$ = new Observable();
+export const event$ = new Observable();
+export const operator$ = new Observable();
+export let print = console.log; // For development purpose.
 
-const createMessageObservable = (source$, messageType) => {
-    return source$.pipe(
-        filter(message => message.type === messageType),
-        pluck('message')
-    );
+const mockMessages = () => {
+    return new Observable(subscriber => {
+        subscriber.next('Hello World.');
+    });
 };
 
-export let print = msg => console.log(msg); // For development purpose.
-export const observable$ = createMessageObservable(backpageMessageSubjectEmiter$, 'observable');
-export const operator$ = createMessageObservable(backpageMessageSubjectEmiter$, 'operator');
-export const event$ = createMessageObservable(backpageMessageSubjectEmiter$, 'event');
-export const reset$ = backpageMessageSubject$.pipe(
-    filter(message => message.type === 'reset'),
-);
+const development = true;
+export const getMessage$ = () => {
+    if (development)
+        return new Promise(resolve => resolve(mockMessages()));
 
-const development = false;
-if (!development) {
-    declare var chrome;
-
-    print = msg => chrome.extension.getBackgroundPage().console.log(msg);
-
+    declare var chrome; // Declaration required to satisfy compiler, filled by chrome.
+    print = msg => chrome.extension.getBackgroundPage().console.log(msg); // Overwrite print to allow content scripts to console.log.
     const backgroundPageConnection = chrome.runtime.connect({
         name: 'messageListener'
     });
 
-
-    backgroundPageConnection.onMessage.addListener(msg => {
-        backpageMessageSubject$.next(msg);
-        if (msg.type === 'operator') {
-            const { type, line, observable } = msg.message;
-            print(`type: ${type} on ${line} with observable ${observable} `);
-        }
-    });
-
-} else {    // Development Block.
-    setTimeout(() => {
-        for (let i = 0; i < 10; i++) {
-            const observable = getObservableMock();
-            backpageMessageSubject$.next(observable);
-            setTimeout(() => {
-                [1, 2, 3].map(() => backpageMessageSubject$.next(getOperatorMock(observable.message.uuid)));
-                [1, 2, 3, 4].map(() => {
-                    getEventMock(observable.message.uuid, 4).map(event => backpageMessageSubject$.next(event));
+    return new Promise(resolve => {
+        resolve(
+            new Observable(subscriber => {
+                backgroundPageConnection.addListener(msg => {
+                    subscriber.next(msg);
                 });
-            }, 100);
-        }
-    }, 100);
+            })
+        );
+    });
+};
 
-    setTimeout(() => {
-        backpageMessageSubject$.next({ type: 'reset' })
-    }, 5000);
+// const timer$ = interval(10);
+// const backpageMessageSubject$ = new Subject();
+// const backpageMessageSubjectEmiter$ = zip(backpageMessageSubject$, timer$).pipe(
+//     map(([value, _]) => value)
+// );
 
-}
+// const createMessageObservable = (source$, messageType) => {
+//     return source$.pipe(
+//         filter(message => message.type === messageType),
+//         pluck('message')
+//     );
+// };
+
+// export let print = msg => console.log(msg); // For development purpose.
+// export const observable$ = createMessageObservable(backpageMessageSubjectEmiter$, 'observable');
+// export const operator$ = createMessageObservable(backpageMessageSubjectEmiter$, 'operator');
+// export const event$ = createMessageObservable(backpageMessageSubjectEmiter$, 'event');
+// export const reset$ = backpageMessageSubject$.pipe(
+//     filter(message => message.type === 'reset'),
+// );
+
+// const development = true;
+// if (!development) {
+//     declare var chrome;
+
+//     print = msg => chrome.extension.getBackgroundPage().console.log(msg);
+
+//     const backgroundPageConnection = chrome.runtime.connect({
+//         name: 'messageListener'
+//     });
+
+
+//     backgroundPageConnection.onMessage.addListener(msg => {
+//         backpageMessageSubject$.next(msg);
+//         if (msg.type === 'operator') {
+//             const { type, line, observable } = msg.message;
+//             print(`type: ${type} on ${line} with observable ${observable} `);
+//         }
+//     });
+
+// } else {    // Development Block.
+//     setTimeout(() => {
+//         for (let i = 0; i < 10; i++) {
+//             const observable = getObservableMock();
+//             backpageMessageSubject$.next(observable);
+//             setTimeout(() => {
+//                 [1, 2, 3].map(() => backpageMessageSubject$.next(getOperatorMock(observable.message.uuid)));
+//                 [1, 2, 3, 4].map(() => {
+//                     getEventMock(observable.message.uuid, 4).map(event => backpageMessageSubject$.next(event));
+//                 });
+//             }, 100);
+//         }
+//     }, 100);
+
+//     setTimeout(() => {
+//         backpageMessageSubject$.next({ type: 'reset' })
+//     }, 5000);
+
+// }

--- a/src/content.js
+++ b/src/content.js
@@ -1,6 +1,6 @@
 //@ts-check
 import { Observable } from 'rxjs';
-import { getObservableMock, getOperatorMock, getPipeMock, getSubscriptionMock } from './mockMessages';
+import { getObservableMock, getOperatorMock, getPipeMock, getSubscriptionMock, getEventMock } from './mockMessages';
 
 export const observable$ = new Observable();    //@TODO: Deprecated.
 export const event$ = new Observable(); //@TODO: Deprecated.
@@ -13,17 +13,24 @@ const mockMessages = () => {
         const observable = getObservableMock();
         const pipe = getPipeMock(observable.message.uuid);
         const pipe2 = getPipeMock(observable.message.uuid);
+        const operator1  = getOperatorMock(observable.message.uuid, pipe.message.uuid);
         dispatchMessage(subscriber, observable);
         dispatchMessage(subscriber, getObservableMock());
         dispatchMessage(subscriber, pipe);
         dispatchMessage(subscriber, pipe2);
-        dispatchMessage(subscriber, getOperatorMock(observable.message.uuid, pipe.message.uuid));
+        dispatchMessage(subscriber, operator1);
         dispatchMessage(subscriber, getOperatorMock(observable.message.uuid, pipe.message.uuid));
         dispatchMessage(subscriber, getOperatorMock(observable.message.uuid, pipe.message.uuid));
         dispatchMessage(subscriber, getOperatorMock(observable.message.uuid, pipe2.message.uuid));
         dispatchMessage(subscriber, getSubscriptionMock(observable.message.uuid, [pipe.message.uuid]));
         dispatchMessage(subscriber, getSubscriptionMock(observable.message.uuid, []));
         dispatchMessage(subscriber, getSubscriptionMock(observable.message.uuid, [pipe2.message.uuid]));
+        dispatchMessage(subscriber, getEventMock('1', pipe, 'initial'));
+        dispatchMessage(subscriber, getEventMock('2', pipe, 'initial'));
+        dispatchMessage(subscriber, getEventMock('3', pipe, 'initial'));
+        dispatchMessage(subscriber, getEventMock('1', operator1.message.uuid, 'operator'));
+        dispatchMessage(subscriber, getEventMock('2', operator1.message.uuid, 'operator'));
+        dispatchMessage(subscriber, getEventMock('3', operator1.message.uuid, 'operator'));
     });
 };
 
@@ -42,6 +49,9 @@ const dispatchMessage = (subscriber, message) => {
         case 'subscription':
             const { message: subscription } = message;
             return subscriber.next({ type: 'subscription', message: subscription });
+        case 'event':
+            const { message: event } = message;
+            return subscriber.next({ type: 'event', message: event });
         default:
             throw new Error(`Invalid message type ${message.type}!`);
     }

--- a/src/content.js
+++ b/src/content.js
@@ -11,9 +11,12 @@ const mockMessages = () => {
     });
 };
 
+let test = function() {
+
+}
 const development = true;
 export const getMessage$ = () => {
-    if (development)
+    if (development)    // Outside extension there is no chrome object.
         return new Promise(resolve => resolve(mockMessages()));
 
     declare var chrome; // Declaration required to satisfy compiler, filled by chrome.
@@ -32,63 +35,3 @@ export const getMessage$ = () => {
         );
     });
 };
-
-// const timer$ = interval(10);
-// const backpageMessageSubject$ = new Subject();
-// const backpageMessageSubjectEmiter$ = zip(backpageMessageSubject$, timer$).pipe(
-//     map(([value, _]) => value)
-// );
-
-// const createMessageObservable = (source$, messageType) => {
-//     return source$.pipe(
-//         filter(message => message.type === messageType),
-//         pluck('message')
-//     );
-// };
-
-// export let print = msg => console.log(msg); // For development purpose.
-// export const observable$ = createMessageObservable(backpageMessageSubjectEmiter$, 'observable');
-// export const operator$ = createMessageObservable(backpageMessageSubjectEmiter$, 'operator');
-// export const event$ = createMessageObservable(backpageMessageSubjectEmiter$, 'event');
-// export const reset$ = backpageMessageSubject$.pipe(
-//     filter(message => message.type === 'reset'),
-// );
-
-// const development = true;
-// if (!development) {
-//     declare var chrome;
-
-//     print = msg => chrome.extension.getBackgroundPage().console.log(msg);
-
-//     const backgroundPageConnection = chrome.runtime.connect({
-//         name: 'messageListener'
-//     });
-
-
-//     backgroundPageConnection.onMessage.addListener(msg => {
-//         backpageMessageSubject$.next(msg);
-//         if (msg.type === 'operator') {
-//             const { type, line, observable } = msg.message;
-//             print(`type: ${type} on ${line} with observable ${observable} `);
-//         }
-//     });
-
-// } else {    // Development Block.
-//     setTimeout(() => {
-//         for (let i = 0; i < 10; i++) {
-//             const observable = getObservableMock();
-//             backpageMessageSubject$.next(observable);
-//             setTimeout(() => {
-//                 [1, 2, 3].map(() => backpageMessageSubject$.next(getOperatorMock(observable.message.uuid)));
-//                 [1, 2, 3, 4].map(() => {
-//                     getEventMock(observable.message.uuid, 4).map(event => backpageMessageSubject$.next(event));
-//                 });
-//             }, 100);
-//         }
-//     }, 100);
-
-//     setTimeout(() => {
-//         backpageMessageSubject$.next({ type: 'reset' })
-//     }, 5000);
-
-// }

--- a/src/content.js
+++ b/src/content.js
@@ -50,7 +50,7 @@ const dispatchMessage = (subscriber, message) => {
         case 'operator':
             const { message: operator } = message;
             return subscriber.next({ type: 'operator', message: operator });
-        case 'subscription':
+        case 'subscribe':
             const { message: subscription } = message;
             return subscriber.next({ type: 'subscription', message: subscription });
         case 'event':

--- a/src/content.js
+++ b/src/content.js
@@ -1,6 +1,6 @@
 //@ts-check
-import { Observable, Subject } from 'rxjs';
-import { getObservableMock } from './mockMessages';
+import { Observable } from 'rxjs';
+import { getObservableMock, getOperatorMock } from './mockMessages';
 
 export const observable$ = new Observable();
 export const event$ = new Observable();
@@ -10,27 +10,29 @@ export let print = console.log; // For development purpose.
 // Mock some messages for development.
 const mockMessages = () => {
     return new Observable(subscriber => {
-        // subscriber.next('Hello World.');
-        dispatchMessage(subscriber, getObservableMock())
+        const observable = getObservableMock();
+        dispatchMessage(subscriber, observable);
+        dispatchMessage(subscriber, getObservableMock());
+        dispatchMessage(subscriber, getOperatorMock(observable.message.uuid));
     });
 };
 
-const childs$ = new Map();
-
-// Dispatch given message over given subscriber.
 const dispatchMessage = (subscriber, message) => {
     switch (message.type) {
         case 'observable':
             const { message: observable } = message;
-            observable.child$ = new Subject();
-            childs$.set(observable.uuid, observable.child$);
-            subscriber.next({ type: 'observable', message: observable }); break;
+            return subscriber.next({ type: 'observable', message: observable });
+        case 'operator':
+            const { message: operator } = message;
+            return subscriber.next({ type: 'operator', message: operator });
+        default:
+            throw new Error(`Invalid message type ${message.type} !`);
     }
 }
 
 const development = true;
 
-// Get message source$.
+// Get promise of message source$.
 export const getMessage$ = () => {
     if (development)   // Outside extension there is no chrome object.
         return new Promise(resolve => resolve(mockMessages()));

--- a/src/content.js
+++ b/src/content.js
@@ -1,40 +1,51 @@
 //@ts-check
 import { Observable } from 'rxjs';
-import { getObservableMock, getOperatorMock } from './mockMessages';
+import { getObservableMock, getOperatorMock, getPipeMock, getSubscriptionMock } from './mockMessages';
 
-export const observable$ = new Observable();
-export const event$ = new Observable();
-export const operator$ = new Observable();
+export const observable$ = new Observable();    //@TODO: Deprecated.
+export const event$ = new Observable(); //@TODO: Deprecated.
+export const operator$ = new Observable();  //@TODO: Deprecated.
 export let print = console.log; // For development purpose.
 
 // Mock some messages for development.
 const mockMessages = () => {
     return new Observable(subscriber => {
         const observable = getObservableMock();
+        const pipe = getPipeMock(observable.message.uuid);
         dispatchMessage(subscriber, observable);
         dispatchMessage(subscriber, getObservableMock());
-        dispatchMessage(subscriber, getOperatorMock(observable.message.uuid));
+        dispatchMessage(subscriber, pipe);
+        dispatchMessage(subscriber, getOperatorMock(observable.message.uuid, pipe.message.uuid));
+        dispatchMessage(subscriber, getSubscriptionMock(observable, [pipe]));
     });
 };
 
+// Pass message along to subscriber.
 const dispatchMessage = (subscriber, message) => {
     switch (message.type) {
         case 'observable':
             const { message: observable } = message;
             return subscriber.next({ type: 'observable', message: observable });
+        case 'pipe':
+            const { message: pipe } = message;
+            return subscriber.next({ type: 'pipe', message: pipe });
         case 'operator':
             const { message: operator } = message;
             return subscriber.next({ type: 'operator', message: operator });
+        case 'subscription':
+            const { message: subscription } = message;
+            return subscriber.next({ type: 'subscription', message: subscription });
         default:
-            throw new Error(`Invalid message type ${message.type} !`);
+            throw new Error(`Invalid message type ${message.type}!`);
     }
 }
 
+// Development flag.
 const development = true;
 
 // Get promise of message source$.
 export const getMessage$ = () => {
-    if (development)   // Outside extension there is no chrome object.
+    if (development)   // Outside extension there is no chrome object, return mocked messages for development.
         return new Promise(resolve => resolve(mockMessages()));
 
     declare var chrome; // Declaration required to satisfy compiler, filled by chrome.

--- a/src/content.js
+++ b/src/content.js
@@ -23,18 +23,18 @@ const mockMessages = () => {
         dispatchMessage(subscriber, subscription1);
         dispatchMessage(subscriber, getSubscriptionMock(observable.message.uuid, []));
         dispatchMessage(subscriber, getSubscriptionMock(observable.message.uuid, [pipe2.message.uuid]));
-        dispatchMessage(subscriber, getEventMock('1', pipe, 'initial'));
-        dispatchMessage(subscriber, getEventMock('2', pipe, 'initial'));
-        dispatchMessage(subscriber, getEventMock('3', pipe, 'initial'));
+        dispatchMessage(subscriber, getEventMock('1', pipe.message.uuid, 'initial'));
+        dispatchMessage(subscriber, getEventMock('2', pipe.message.uuid, 'initial'));
+        dispatchMessage(subscriber, getEventMock('3', pipe.message.uuid, 'initial'));
         dispatchMessage(subscriber, getEventMock('1', operator1.message.uuid, 'operator'));
         dispatchMessage(subscriber, getEventMock('2', operator1.message.uuid, 'operator'));
         dispatchMessage(subscriber, getEventMock('3', operator1.message.uuid, 'operator'));
         dispatchMessage(subscriber, getEventMock('1', subscription1.message.uuid, 'subscribe'));
         dispatchMessage(subscriber, getEventMock('2', subscription1.message.uuid, 'subscribe'));
         dispatchMessage(subscriber, getEventMock('3', subscription1.message.uuid, 'subscribe'));
-        setTimeout(() => {
-            dispatchMessage(subscriber, { type: 'reset' });
-        }, 5000);
+        // setTimeout(() => {
+        //     dispatchMessage(subscriber, { type: 'reset' });
+        // }, 5000);
     });
 };
 
@@ -43,19 +43,25 @@ const dispatchMessage = (subscriber, message) => {
     switch (message.type) {
         case 'observable':
             const { message: observable } = message;
+            print(`observable line ${observable.line} uuid ${observable.uuid}`);
             return subscriber.next({ type: 'observable', message: observable });
         case 'pipe':
             const { message: pipe } = message;
+            print(`pipe line ${pipe.line} uuid ${pipe.uuid} observable ${pipe.observable}`);
             return subscriber.next({ type: 'pipe', message: pipe });
         case 'operator':
             const { message: operator } = message;
+            print(`operator ${operator.function} line ${operator.line} pipe ${operator.pipe}`);
             return subscriber.next({ type: 'operator', message: operator });
         case 'subscribe':
             const { message: subscription } = message;
+            print(`subscription line ${subscription.line} observable ${subscription.observable}`);
             return subscriber.next({ type: 'subscription', message: subscription });
         case 'event':
             const { message: event } = message;
             return subscriber.next({ type: 'event', message: event });
+        case 'subscribeEvent': // TODO: Implement.
+            break;
         case 'reset':
             return subscriber.next(message);
         default:

--- a/src/content.js
+++ b/src/content.js
@@ -2,9 +2,6 @@
 import { Observable } from 'rxjs';
 import { getObservableMock, getOperatorMock, getPipeMock, getSubscriptionMock, getEventMock } from './mockMessages';
 
-export const observable$ = new Observable();    //@TODO: Deprecated.
-export const event$ = new Observable(); //@TODO: Deprecated.
-export const operator$ = new Observable();  //@TODO: Deprecated.
 export let print = console.log; // For development purpose.
 
 // Mock some messages for development.
@@ -13,7 +10,7 @@ const mockMessages = () => {
         const observable = getObservableMock();
         const pipe = getPipeMock(observable.message.uuid);
         const pipe2 = getPipeMock(observable.message.uuid);
-        const operator1  = getOperatorMock(observable.message.uuid, pipe.message.uuid);
+        const operator1 = getOperatorMock(observable.message.uuid, pipe.message.uuid);
         const subscription1 = getSubscriptionMock(observable.message.uuid, [pipe.message.uuid]);
         dispatchMessage(subscriber, observable);
         dispatchMessage(subscriber, getObservableMock());
@@ -35,6 +32,9 @@ const mockMessages = () => {
         dispatchMessage(subscriber, getEventMock('1', subscription1.message.uuid, 'subscribe'));
         dispatchMessage(subscriber, getEventMock('2', subscription1.message.uuid, 'subscribe'));
         dispatchMessage(subscriber, getEventMock('3', subscription1.message.uuid, 'subscribe'));
+        setTimeout(() => {
+            dispatchMessage(subscriber, { type: 'reset' });
+        }, 5000);
     });
 };
 
@@ -56,6 +56,8 @@ const dispatchMessage = (subscriber, message) => {
         case 'event':
             const { message: event } = message;
             return subscriber.next({ type: 'event', message: event });
+        case 'reset':
+            return subscriber.next(message);
         default:
             throw new Error(`Invalid message type ${message.type}!`);
     }

--- a/src/contexts/eventContext.js
+++ b/src/contexts/eventContext.js
@@ -15,6 +15,8 @@ const reducer = (state, action) => {
             return { ...state, initialEvents: [...state.initialEvents, action.payload] };
         case 'operator':
             return { ...state, operatorEvents: [...state.operatorEvents, action.payload] };
+        case 'subscribe':
+            return { ...state, subscribeEvents: [...state.subscribeEvents, action.payload] };
         default:
             throw new Error(`Invalid event type given ${action.type}!`);
     }

--- a/src/contexts/eventContext.js
+++ b/src/contexts/eventContext.js
@@ -1,0 +1,33 @@
+import React, { createContext, useReducer } from 'react';
+
+export const EventContext = createContext();
+export const DispatchContext = createContext();
+
+const initialState = {
+    initialEvents: [],
+    operatorEvents: [],
+    subscribeEvents: []
+};
+
+const reducer = (state, action) => {
+    switch (action.type) {
+        case 'initial':
+            return { ...state, initialEvents: [...state.initialEvents, action.payload] };
+        case 'operator':
+            return { ...state, operatorEvents: [...state.operatorEvents, action.payload] };
+        default:
+            throw new Error(`Invalid event type given ${action.type}!`);
+    }
+};
+
+export const EventProvider = (props) => {
+    const [events, dispatch] = useReducer(reducer, initialState);
+
+    return (
+        <EventContext.Provider value={events}>
+            <DispatchContext.Provider value={dispatch}>
+                {props.children}
+            </DispatchContext.Provider>
+        </EventContext.Provider>
+    );
+};

--- a/src/contexts/observableContext.js
+++ b/src/contexts/observableContext.js
@@ -1,0 +1,27 @@
+import React, { createContext, useReducer } from 'react';
+
+export const ObservableContext = createContext();
+
+const initalState = {
+    observables: [],
+    pipes: [],
+    operators: [],
+    subscribers: []
+}
+
+const reducer = (action, payload) => {
+    switch (action.type) {
+        default:
+            throw new Error('Invalid action type!');
+    }
+};
+
+export const ObservableProvider = (props) => {
+    const [observables, dispatch] = useReducer(reducer, initalState);
+
+    return (
+        <ObservableContext.Provider value={observables, dispatch}>
+            {props.children}
+        </ObservableContext.Provider>
+    )
+};

--- a/src/contexts/observableContext.js
+++ b/src/contexts/observableContext.js
@@ -13,10 +13,11 @@ const initalState = {
 const reducer = (state, action) => {
     switch (action.type) {
         case 'observable':
-            console.log(action.payload);
             return { ...state, observables: [...state.observables, action.payload] };
+        case 'operator':
+            return { ...state, operators: [...state.operators, action.payload] };
         default:
-            throw new Error('Invalid action type!');
+            throw new Error(`Invalid action type ${action.type}!`);
     }
 };
 

--- a/src/contexts/observableContext.js
+++ b/src/contexts/observableContext.js
@@ -8,7 +8,7 @@ const initalState = {
     pipes: [],
     operators: [],
     subscribers: []
-}
+};
 
 const reducer = (state, action) => {
     switch (action.type) {

--- a/src/contexts/observableContext.js
+++ b/src/contexts/observableContext.js
@@ -3,7 +3,7 @@ import React, { createContext, useReducer } from 'react';
 export const ObservableContext = createContext();
 export const DispatchContext = createContext();
 
-const initalState = {
+const initialState = {
     observables: [],
     pipes: [],
     operators: [],
@@ -20,13 +20,15 @@ const reducer = (state, action) => {
             return { ...state, operators: [...state.operators, action.payload] };
         case 'subscription':
             return { ...state, subscribers: [...state.subscribers, action.payload] };
+        case 'reset':
+            return initialState;
         default:
             throw new Error(`Invalid action type ${action.type}!`);
     }
 };
 
 export const ObservableProvider = (props) => {
-    const [observables, dispatch] = useReducer(reducer, initalState);
+    const [observables, dispatch] = useReducer(reducer, initialState);
 
     return (
         <ObservableContext.Provider value={observables}>

--- a/src/contexts/observableContext.js
+++ b/src/contexts/observableContext.js
@@ -12,9 +12,9 @@ const initalState = {
 
 const reducer = (state, action) => {
     switch (action.type) {
-        case 'test':
+        case 'observable':
             console.log(action.payload);
-            break;
+            return { ...state, observables: [...state.observables, action.payload] };
         default:
             throw new Error('Invalid action type!');
     }

--- a/src/contexts/observableContext.js
+++ b/src/contexts/observableContext.js
@@ -14,8 +14,12 @@ const reducer = (state, action) => {
     switch (action.type) {
         case 'observable':
             return { ...state, observables: [...state.observables, action.payload] };
+        case 'pipe':
+            return { ...state, pipes: [...state.pipes, action.payload] };
         case 'operator':
             return { ...state, operators: [...state.operators, action.payload] };
+        case 'subscription':
+            return { ...state, subscribers: [...state.subscribers, action.payload] };
         default:
             throw new Error(`Invalid action type ${action.type}!`);
     }

--- a/src/contexts/observableContext.js
+++ b/src/contexts/observableContext.js
@@ -1,6 +1,7 @@
 import React, { createContext, useReducer } from 'react';
 
 export const ObservableContext = createContext();
+export const DispatchContext = createContext();
 
 const initalState = {
     observables: [],
@@ -9,8 +10,11 @@ const initalState = {
     subscribers: []
 }
 
-const reducer = (action, payload) => {
+const reducer = (state, action) => {
     switch (action.type) {
+        case 'test':
+            console.log(action.payload);
+            break;
         default:
             throw new Error('Invalid action type!');
     }
@@ -20,8 +24,10 @@ export const ObservableProvider = (props) => {
     const [observables, dispatch] = useReducer(reducer, initalState);
 
     return (
-        <ObservableContext.Provider value={observables, dispatch}>
-            {props.children}
+        <ObservableContext.Provider value={observables}>
+            <DispatchContext.Provider value={dispatch}>
+                {props.children}
+            </DispatchContext.Provider>
         </ObservableContext.Provider>
     )
 };

--- a/src/devtoolsPane.js
+++ b/src/devtoolsPane.js
@@ -1,32 +1,48 @@
-import React, { useState, useLayoutEffect } from 'react';
+import React, { useState, useLayoutEffect, useContext, useEffect } from 'react';
 import './devtoolsPane.css';
 import Subscription from './subscription';
-import { observable$, reset$ } from './content';
+import { observable$, reset$, getMessage$ } from './content';
 import * as uuid from 'uuid/v4';
 import { take } from 'rxjs/operators';
+import { DispatchContext, ObservableContext } from './contexts/observableContext';
 
 export default function DevtoolsPane() {
-    const createSubscription = (uuid, observable, type) => ({ uuid, observable, type });
-    const [subscriptions, setSubscriptions] = useState([]);
+    const dispatch = useContext(DispatchContext);
+    const observables = useContext(ObservableContext);
 
-    useLayoutEffect(() => {
-        const subscription = observable$.subscribe(sub => {
-            setSubscriptions(subs => [createSubscription(sub.uuid, sub.identifier, sub.type), ...subs])
-        });
+    useEffect(() => {
+        (async () => {
+            const message$ = await getMessage$();
+            const subscription = message$.subscribe(msg => {
+                dispatch({ type: 'test', payload: msg });
+            });
 
-        reset$.subscribe(() => {
-            setSubscriptions([]);
-        });
-
-        return () => subscription.unsubscribe();
+            return () => subscription.unsubscribe();
+        })();
     }, []);
 
+    // const createSubscription = (uuid, observable, type) => ({ uuid, observable, type });
+    // const [subscriptions, setSubscriptions] = useState([]);
+
+    // useLayoutEffect(() => {
+    //     const subscription = observable$.subscribe(sub => {
+    //         setSubscriptions(subs => [createSubscription(sub.uuid, sub.identifier, sub.type), ...subs])
+    //     });
+
+    //     reset$.subscribe(() => {
+    //         setSubscriptions([]);
+    //     });
+
+    //     return () => subscription.unsubscribe();
+    // }, []);
+
     return (
-        <div className='DevtoolsPane'>
-            {subscriptions
+        <div className='DevtoolsPane' onClick={() => dispatch({ type: 'test', payload: 1 })}>
+            test
+            {/* {subscriptions
                 .map(sub => {
                     return <Subscription key={uuid()} uuid={sub.uuid} observable={sub.observable} type={sub.type}></Subscription>
-                })}
+                })} */}
         </div>
     );
 }

--- a/src/devtoolsPane.js
+++ b/src/devtoolsPane.js
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import './devtoolsPane.css';
-import Subscription from './subscription';
+import Observable from './observable';
 import { getMessage$ } from './content';
 import * as uuid from 'uuid/v4';
 import { DispatchContext, ObservableContext } from './contexts/observableContext';
@@ -9,6 +9,7 @@ export default function DevtoolsPane() {
     const dispatch = useContext(DispatchContext);
     const { observables } = useContext(ObservableContext);
 
+    // Receive messages from content script and feed to observable dispatcher.
     useEffect(() => {
         (async () => {
             const message$ = await getMessage$();
@@ -22,10 +23,9 @@ export default function DevtoolsPane() {
 
     return (
         <div className='DevtoolsPane'>
-            test
             {observables
                 .map(observable => {
-                    return <Subscription key={uuid()} uuid={observable.uuid} type={observable.type}></Subscription>
+                    return <Observable key={uuid()} observable={observable.uuid} type={observable.type}></Observable>
                 })}
         </div>
     );

--- a/src/devtoolsPane.js
+++ b/src/devtoolsPane.js
@@ -18,7 +18,7 @@ export default function DevtoolsPane() {
             const subscription = message$.subscribe(msg => {
                 if (msg.type === 'event') {
                     const { message } = msg;
-                    eventDispatch({ type: message.type, payload: message });
+                    eventDispatch({ type: message.type, payload: msg.message });
                 } else {
                     observableDispatch({ type: msg.type, payload: msg.message });
                 }

--- a/src/devtoolsPane.js
+++ b/src/devtoolsPane.js
@@ -10,11 +10,13 @@ export default function DevtoolsPane() {
     const dispatch = useContext(DispatchContext);
     const observables = useContext(ObservableContext);
 
+    console.log(observables);
+
     useEffect(() => {
         (async () => {
             const message$ = await getMessage$();
             const subscription = message$.subscribe(msg => {
-                dispatch({ type: 'test', payload: msg });
+                dispatch({ type: msg.type, payload: msg.message });
             });
 
             return () => subscription.unsubscribe();
@@ -39,10 +41,10 @@ export default function DevtoolsPane() {
     return (
         <div className='DevtoolsPane' onClick={() => dispatch({ type: 'test', payload: 1 })}>
             test
-            {/* {subscriptions
+            {observables.observables
                 .map(sub => {
-                    return <Subscription key={uuid()} uuid={sub.uuid} observable={sub.observable} type={sub.type}></Subscription>
-                })} */}
+                    return <Subscription key={uuid()} uuid={sub.uuid} observable={sub.observable} type={sub.type} child$={sub.child$}></Subscription>
+                })}
         </div>
     );
 }

--- a/src/devtoolsPane.js
+++ b/src/devtoolsPane.js
@@ -18,7 +18,7 @@ export default function DevtoolsPane() {
             const subscription = message$.subscribe(msg => {
                 if (msg.type === 'event') {
                     const { message } = msg;
-                    eventDispatch({ type: message.eventType, payload: message });
+                    eventDispatch({ type: message.type, payload: message });
                 } else {
                     observableDispatch({ type: msg.type, payload: msg.message });
                 }

--- a/src/devtoolsPane.js
+++ b/src/devtoolsPane.js
@@ -1,16 +1,13 @@
-import React, { useState, useLayoutEffect, useContext, useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import './devtoolsPane.css';
 import Subscription from './subscription';
-import { observable$, reset$, getMessage$ } from './content';
+import { getMessage$ } from './content';
 import * as uuid from 'uuid/v4';
-import { take } from 'rxjs/operators';
 import { DispatchContext, ObservableContext } from './contexts/observableContext';
 
 export default function DevtoolsPane() {
     const dispatch = useContext(DispatchContext);
-    const observables = useContext(ObservableContext);
-
-    console.log(observables);
+    const { observables } = useContext(ObservableContext);
 
     useEffect(() => {
         (async () => {
@@ -21,29 +18,14 @@ export default function DevtoolsPane() {
 
             return () => subscription.unsubscribe();
         })();
-    }, []);
-
-    // const createSubscription = (uuid, observable, type) => ({ uuid, observable, type });
-    // const [subscriptions, setSubscriptions] = useState([]);
-
-    // useLayoutEffect(() => {
-    //     const subscription = observable$.subscribe(sub => {
-    //         setSubscriptions(subs => [createSubscription(sub.uuid, sub.identifier, sub.type), ...subs])
-    //     });
-
-    //     reset$.subscribe(() => {
-    //         setSubscriptions([]);
-    //     });
-
-    //     return () => subscription.unsubscribe();
-    // }, []);
+    }, [dispatch]);
 
     return (
-        <div className='DevtoolsPane' onClick={() => dispatch({ type: 'test', payload: 1 })}>
+        <div className='DevtoolsPane'>
             test
-            {observables.observables
-                .map(sub => {
-                    return <Subscription key={uuid()} uuid={sub.uuid} observable={sub.observable} type={sub.type} child$={sub.child$}></Subscription>
+            {observables
+                .map(observable => {
+                    return <Subscription key={uuid()} uuid={observable.uuid} type={observable.type}></Subscription>
                 })}
         </div>
     );

--- a/src/marble.css
+++ b/src/marble.css
@@ -7,7 +7,7 @@ div.Marble {
     height: 30px;
     border-radius: 15px 15px;
     display: flex;
-    justify-content: center;
+    justify-content: start;
     align-items: center;
     margin: 1px;
 }

--- a/src/marble.css
+++ b/src/marble.css
@@ -7,7 +7,7 @@ div.Marble {
     height: 30px;
     border-radius: 15px 15px;
     display: flex;
-    justify-content: start;
+    justify-content: flex-start;
     align-items: center;
     margin: 1px;
 }

--- a/src/marbleLane.css
+++ b/src/marbleLane.css
@@ -1,4 +1,5 @@
 div.MarbleLane {
     display: flex;
     flex-direction: row;
+    width: 100%;
 }

--- a/src/mockMessages.js
+++ b/src/mockMessages.js
@@ -77,44 +77,16 @@ export const getSubscriptionMock = (observable, pipes) => {
     };
 };
 
-export const getEventMock = (observable, phases) => {
-    const id = uuid();
-    const result = [];
-    for (let i = 0; i < phases; i++) {
-        result.push(
-            {
-                type: 'event',
-                message: {
-                    data: getRandomInteger(),
-                    observable: observable,
-                    uuid: id,
-                    file: 'mockMessages.js',
-                    line: 53
-                }
-            }
-        );
-    }
-    return result;
-};
-
-const eventMessage = {
-    type: 'event',
-    message: {
-        data: '1',
-        observable: '1',
-        uuid: '1',
-        file: '/app/app_component.ts',
-        line: 12
-    }
-};
-
-const eventMessage2 = {
-    type: 'event',
-    message: {
-        data: 'b',
-        observable: '1',
-        uuid: '2',
-        file: '/app/app_component.ts',
-        line: 12
+export const getEventMock = (id, receiver, eventType) => {
+    return {
+        type: 'event',
+        message: {
+            id: id,
+            data: getRandomInteger(),
+            receiver: receiver,
+            eventType: eventType,
+            file: 'mockMessages.js',
+            line: 80
+        }
     }
 };

--- a/src/mockMessages.js
+++ b/src/mockMessages.js
@@ -36,6 +36,19 @@ export const getObservableMock = () => {
     };
 }
 
+export const getPipeMock = observable => {
+    return {
+        type: 'pipe',
+        message: {
+            uuid: uuid(),
+            observable: observable,
+            identifier: 'anonymous',
+            file: 'mockMessages.js',
+            line: 39
+        }
+    };
+}
+
 export const getOperatorMock = observable => {
     return {
         type: 'operator',
@@ -49,6 +62,19 @@ export const getOperatorMock = observable => {
         }
     }
 }
+
+export const getSubscriptionMock = (observable, pipes) => {
+    return {
+        type: 'subscription',
+        message: {
+            observable: observable,
+            pipes: pipes,
+            function: '(x => console.log(x))',
+            file: 'mockMessages.js',
+            line: 66
+        }
+    };
+};
 
 export const getEventMock = (observable, phases) => {
     const id = uuid();

--- a/src/mockMessages.js
+++ b/src/mockMessages.js
@@ -66,7 +66,7 @@ export const getOperatorMock = (observable, pipe = null) => {
 
 export const getSubscriptionMock = (observable, pipes) => {
     return {
-        type: 'subscription',
+        type: 'subscribe',
         message: {
             uuid: uuid(),
             observable: observable,

--- a/src/mockMessages.js
+++ b/src/mockMessages.js
@@ -49,7 +49,7 @@ export const getPipeMock = observable => {
     };
 }
 
-export const getOperatorMock = observable => {
+export const getOperatorMock = (observable, pipe = null) => {
     return {
         type: 'operator',
         message: {
@@ -57,6 +57,7 @@ export const getOperatorMock = observable => {
             type: getRandomOperatorType(),
             function: 'x => x += 1',
             observable: observable,
+            pipe: pipe,
             file: 'mockMessages.js',
             line: 37
         }

--- a/src/mockMessages.js
+++ b/src/mockMessages.js
@@ -85,7 +85,7 @@ export const getEventMock = (id, receiver, eventType) => {
             id: id,
             data: getRandomInteger(),
             receiver: receiver,
-            eventType: eventType,
+            type: eventType,
             file: 'mockMessages.js',
             line: 80
         }

--- a/src/mockMessages.js
+++ b/src/mockMessages.js
@@ -68,6 +68,7 @@ export const getSubscriptionMock = (observable, pipes) => {
     return {
         type: 'subscription',
         message: {
+            uuid: uuid(),
             observable: observable,
             pipes: pipes,
             function: '(x => console.log(x))',

--- a/src/observable.css
+++ b/src/observable.css
@@ -1,0 +1,43 @@
+div.Observable {
+    background-color: #f0f0f0;
+    font-size: 0.75em;
+    margin: 1px 0;
+    padding: 1px;
+    width: 99%;
+}
+
+div.Observable div.header.open {
+    background-color: lightblue;
+}
+
+div.Observable div.header:hover {
+    background-color: lightblue;
+    cursor: pointer;
+}
+
+div.Observable div.header.open:hover {
+    background-color: lightcoral;
+    cursor: pointer;
+}
+
+div.Observable div.header.unsubscribed {
+    background-color: lightcoral;
+}
+
+span {
+    margin-right: 2px;
+}
+
+span.fat {
+    font-weight: bold;
+}
+
+div.marble-diagram {
+    background-color: white;
+    width: 100%;
+    display: none;
+}
+
+div.marble-diagram.open {
+    display: inline-block;
+}

--- a/src/observable.js
+++ b/src/observable.js
@@ -29,7 +29,7 @@ export default function Observable(props) {
             <div className={`marble-diagram${open ? ' open' : ''}`}>
                 {subscriptions()
                     .map(sub => {
-                        return <Subscription key={uuid()} pipes={sub.pipes} line={sub.line} file={sub.file} />
+                        return <Subscription key={uuid()} uuid={sub.uuid} pipes={sub.pipes} line={sub.line} file={sub.file} />
                     })
                 }
             </div>

--- a/src/observable.js
+++ b/src/observable.js
@@ -1,0 +1,38 @@
+import React, { useState, useContext } from 'react';
+import './observable.css';
+import { ObservableContext } from './contexts/observableContext';
+import * as uuid from 'uuid/v4';
+import Subscription from './subscription';
+
+export default function Observable(props) {
+    const [open, setOpen] = useState(false);
+    const { subscribers } = useContext(ObservableContext);
+
+    const openObservable = () => {
+        setOpen(!open);
+    };
+
+    const subscriptions = () => {
+        return subscribers.filter(sub => sub.observable === props.observable);
+    };
+
+    return (
+        <div className='Observable'>
+            <div
+                className={`header${open ? ' open' : ''}${!subscriptions().length ? ' unsubscribed' : ''}`}
+                onClick={openObservable}>
+                <span className='fat'>{props.observable}</span>
+                <span className='fat'>{props.type}</span>
+                <span>{props.uuid}</span>
+            </div>
+
+            <div className={`marble-diagram${open ? ' open' : ''}`}>
+                {subscriptions()
+                    .map(sub => {
+                        return <Subscription key={uuid()} pipes={sub.pipes} line={sub.line} file={sub.file} />
+                    })
+                }
+            </div>
+        </div>
+    );
+}

--- a/src/operator.css
+++ b/src/operator.css
@@ -1,10 +1,11 @@
 div.Operator {
-    width: 80%;
+    width: 60%;
     border: 2px solid black;
     height: 4vh;
     display: flex;
     align-items: center;
     justify-content: center;
+    align-self: center;
 }
 
 div.Operator span {

--- a/src/operator.css
+++ b/src/operator.css
@@ -1,5 +1,5 @@
 div.Operator {
-    width: 99%;
+    width: 80%;
     border: 2px solid black;
     height: 4vh;
     display: flex;

--- a/src/pipe.css
+++ b/src/pipe.css
@@ -1,0 +1,7 @@
+div.Pipe {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}

--- a/src/pipe.css
+++ b/src/pipe.css
@@ -2,6 +2,11 @@ div.Pipe {
     width: 100%;
     display: flex;
     flex-direction: column;
-    justify-content: center;
-    align-items: center;
+    align-items: flex-start;
+}
+
+div.Pipe div.operatorMarbleSet {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
 }

--- a/src/pipe.js
+++ b/src/pipe.js
@@ -1,0 +1,20 @@
+import React, { useContext } from 'react';
+import { ObservableContext } from './contexts/observableContext';
+import * as uuid from 'uuid/v4';
+import './pipe.css';
+import Operator from './operator';
+
+export default function Pipe(props) {
+    const { operators } = useContext(ObservableContext);
+
+    return (
+        <div className='Pipe'>
+            {operators
+                .filter(operator => operator.pipe === props.pipe)
+                .map(operator => {
+                    return <Operator key={uuid()} fn={operator.type} />
+                })
+            }
+        </div>
+    );
+}

--- a/src/pipe.js
+++ b/src/pipe.js
@@ -11,13 +11,17 @@ export default function Pipe(props) {
     const { initialEvents, operatorEvents } = useContext(EventContext);
 
     const initialEventData = () => {
-        return initialEvents.map(event => event.data);
+        return initialEvents
+            .filter(event => event.receiver === props.pipe)
+            .map(event => event.data)
+            .map(event => JSON.stringify(event));
     };
 
     const eventsForOperator = operator => {
         return operatorEvents
             .filter(event => event.receiver === operator)
-            .map(event => event.data);
+            .map(event => event.data)
+            .map(event => JSON.stringify(event));
     };
 
     return (

--- a/src/pipe.js
+++ b/src/pipe.js
@@ -3,16 +3,36 @@ import { ObservableContext } from './contexts/observableContext';
 import * as uuid from 'uuid/v4';
 import './pipe.css';
 import Operator from './operator';
+import MarbleLane from './marbleLane';
+import { EventContext } from './contexts/eventContext';
 
 export default function Pipe(props) {
     const { operators } = useContext(ObservableContext);
+    const { initialEvents, operatorEvents } = useContext(EventContext);
+
+    const initialEventData = () => {
+        return initialEvents.map(event => event.data);
+    };
+
+    const eventsForOperator = operator => {
+        return operatorEvents
+            .filter(event => event.receiver === operator)
+            .map(event => event.data);
+    };
 
     return (
         <div className='Pipe'>
+            {/* For initial marbles */}
+            <MarbleLane marbles={initialEventData()} />
             {operators
                 .filter(operator => operator.pipe === props.pipe)
                 .map(operator => {
-                    return <Operator key={uuid()} fn={operator.type} />
+                    return (
+                        <div key={uuid()} className='operatorMarbleSet'>
+                            <Operator uuid={operator.uuid} fn={operator.type} />
+                            <MarbleLane marbles={eventsForOperator(operator.uuid)} />
+                        </div>
+                    );
                 })
             }
         </div>

--- a/src/subscription.css
+++ b/src/subscription.css
@@ -1,39 +1,21 @@
 div.Subscription {
-    background-color: #f0f0f0;
-    font-size: 0.75em;
-    margin: 1px 0;
-    padding: 1px;
-    width: 99%;
-}
-
-div.header.open {
-    background-color: lightblue;
-}
-
-div.header:hover {
-    background-color: lightblue;
-    cursor: pointer;
-}
-
-div.header.open:hover {
-    background-color: lightcoral;
-    cursor: pointer;
-}
-
-span {
-    margin-right: 2px;
-}
-
-span.fat {
-    font-weight: bold;
-}
-
-div.marble-diagram {
-    background-color: white;
+    border: 1px solid black;
     width: 100%;
+}
+
+div.Subscription div.content {
     display: none;
 }
 
-div.marble-diagram.open {
+div.Subscription div.content.open {
+    width: calc(100% - 2px);
     display: inline-block;
+}
+
+div.Subscription span {
+    margin: 0.2em;
+}
+
+div.Subscription span:first-of-type {
+    padding-left: 2vw;
 }

--- a/src/subscription.js
+++ b/src/subscription.js
@@ -1,9 +1,12 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import './subscription.css';
 import MarbleDiagram from './marbleDiagram';
+import { ObservableContext } from './contexts/observableContext';
+import * as uuid from 'uuid/v4';
 
 export default function Subscription(props) {
     const [open, setOpen] = useState(false);
+    const { operators } = useContext(ObservableContext);
 
     const openSubscription = () => {
         setOpen(!open);
@@ -18,7 +21,12 @@ export default function Subscription(props) {
             </div>
 
             <div className={`marble-diagram${open ? ' open' : ''}`}>
-                <MarbleDiagram observable={props.uuid}></MarbleDiagram>
+                {operators
+                    .filter(operator => operator.observable === props.uuid)
+                    .map(operator => {
+                        return <div key={uuid()}>{operator.function}</div>
+                    })}
+                {/* <MarbleDiagram observable={props.uuid}></MarbleDiagram> */}
             </div>
         </div>
     );

--- a/src/subscription.js
+++ b/src/subscription.js
@@ -3,13 +3,22 @@ import { ObservableContext } from './contexts/observableContext';
 import * as uuid from 'uuid/v4';
 import Pipe from './pipe';
 import './subscription.css';
+import { EventContext } from './contexts/eventContext';
+import MarbleLane from './marbleLane';
 
 export default function Subscription(props) {
     const [open, setOpen] = useState(false);
     const { pipes } = useContext(ObservableContext);
+    const { subscribeEvents } = useContext(EventContext);
 
     const openSubscription = () => {
         setOpen(!open);
+    };
+
+    const eventsForSubscription = subscription => {
+        return subscribeEvents
+            .filter(event => event.receiver === subscription)
+            .map(event => event.data);
     };
 
     return (
@@ -27,6 +36,7 @@ export default function Subscription(props) {
                         return <Pipe key={uuid()} pipe={pipe.uuid} />
                     })
                 }
+                <MarbleLane marbles={eventsForSubscription(props.uuid)} />
             </div>
         </div>
     );

--- a/src/subscription.js
+++ b/src/subscription.js
@@ -18,7 +18,8 @@ export default function Subscription(props) {
     const eventsForSubscription = subscription => {
         return subscribeEvents
             .filter(event => event.receiver === subscription)
-            .map(event => event.data);
+            .map(event => event.data)
+            .map(event => JSON.stringify(event));
     };
 
     return (

--- a/src/subscription.js
+++ b/src/subscription.js
@@ -1,12 +1,12 @@
-import React, { useState, useContext } from 'react';
-import './subscription.css';
-import MarbleDiagram from './marbleDiagram';
+import React, { useContext, useState } from 'react';
 import { ObservableContext } from './contexts/observableContext';
 import * as uuid from 'uuid/v4';
+import Pipe from './pipe';
+import './subscription.css';
 
 export default function Subscription(props) {
     const [open, setOpen] = useState(false);
-    const { operators } = useContext(ObservableContext);
+    const { pipes } = useContext(ObservableContext);
 
     const openSubscription = () => {
         setOpen(!open);
@@ -15,19 +15,19 @@ export default function Subscription(props) {
     return (
         <div className='Subscription'>
             <div className={`header${open ? ' open' : ''}`} onClick={openSubscription}>
-                <span className='fat'>{props.observable}</span>
-                <span className='fat'>{props.type}</span>
-                <span>{props.uuid}</span>
+                <span>line</span>
+                <span className='fat'>{props.line}</span>
+                <span>file</span>
+                <span className='fat' >{props.file}</span>
             </div>
-
-            <div className={`marble-diagram${open ? ' open' : ''}`}>
-                {operators
-                    .filter(operator => operator.observable === props.uuid)
-                    .map(operator => {
-                        return <div key={uuid()}>{operator.function}</div>
-                    })}
-                {/* <MarbleDiagram observable={props.uuid}></MarbleDiagram> */}
+            <div className={`content${open ? ' open' : ''}`}>
+                {pipes
+                    .filter(pipe => props.pipes.includes(pipe.uuid))
+                    .map(pipe => {
+                        return <Pipe key={uuid()} pipe={pipe.uuid} />
+                    })
+                }
             </div>
         </div>
     );
-}
+};


### PR DESCRIPTION
Rewritten logic to replace observable message flow with context hooks.

Because of the time rendering required for components and the hot nature of objects with outer producers, in this  case being the message handler, messages sent before components where rendered  where lost. This caused messages not appearing in the GUI.

With the context, messages are stored in the context and  fetched after rendering, without loss.